### PR TITLE
people-counting-client: Create Device Service and wire up device

### DIFF
--- a/people-counting-system/people-counting-api/package.json
+++ b/people-counting-system/people-counting-api/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.5.0",
   "dependencies": {
+    "@koa/cors": "^5.0.0",
     "dotenv": "^16.5.0",
     "koa": "^3.0.0",
     "koa-bodyparser": "^4.4.1",
@@ -26,6 +27,7 @@
     "@types/koa": "^2.15.0",
     "@types/koa-bodyparser": "^4.3.12",
     "@types/koa-router": "^7.4.8",
+    "@types/koa__cors": "^5.0.0",
     "@types/node": "^22.15.19",
     "@types/pg": "^8.15.2",
     "nodemon": "^3.1.0",

--- a/people-counting-system/people-counting-api/src/app.ts
+++ b/people-counting-system/people-counting-api/src/app.ts
@@ -3,10 +3,12 @@ import Router from 'koa-router';
 import bodyParser from 'koa-bodyparser';
 import { config } from './config';
 import { router as v1Router } from './v1/router';
+import cors from '@koa/cors';
 
 const app = new Koa();
 const router = new Router();
 
+app.use(cors());
 app.use(bodyParser());
 
 router.get('/health', async (ctx) => {

--- a/people-counting-system/people-counting-client/src/app/add-device/add-device.page.html
+++ b/people-counting-system/people-counting-client/src/app/add-device/add-device.page.html
@@ -32,7 +32,7 @@
 
                 <ion-item>
                   <ion-select
-                    [(ngModel)]="device.location"
+                    [(ngModel)]="device.locationId"
                     name="location"
                     required
                     #location="ngModel"

--- a/people-counting-system/people-counting-client/src/app/add-device/add-device.page.ts
+++ b/people-counting-system/people-counting-client/src/app/add-device/add-device.page.ts
@@ -2,6 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
+import { DeviceService, Device } from '../services/device.service';
+import { Router } from '@angular/router';
+
 import {
   IonContent,
   IonHeader,
@@ -71,10 +74,13 @@ import { Observable, of } from 'rxjs';
 })
 
 export class AddDevicePage implements OnInit {
-  device = { name: '', location: '', active :false };
+  device: Partial<Device> = { name: '', locationId: 0, active: false };
   locations$!: Observable<any[]>; 
 
-  constructor() {
+  constructor(
+    private deviceService: DeviceService,
+    private router: Router
+  ) {
   addIcons({
     addCircle,
     eyeOutline,
@@ -138,7 +144,14 @@ ngOnInit() {
   }
 
   addDevice() {
-    //TODO: Implement the logic to add a new device
-    console.log("Add Device button clicked");
+    // Ensure locationId is a number
+    if (!this.device.name || !this.device.locationId) return;
+    this.deviceService.createDevice(this.device as Device).subscribe({
+      next: () => this.router.navigate(['/device']),
+      error: err => {
+        // TODO: Show error to user
+        console.error('Failed to add device', err);
+      }
+    });
   }
 }

--- a/people-counting-system/people-counting-client/src/app/device/device.page.html
+++ b/people-counting-system/people-counting-client/src/app/device/device.page.html
@@ -42,7 +42,12 @@
         >
           <ion-icon name="create-outline"></ion-icon>
         </ion-button>
-        <ion-button fill="outline" size="default" color="danger">
+        <ion-button
+          fill="outline"
+          size="default"
+          color="danger"
+          (click)="deleteDevice(device.id)"
+        >
           <ion-icon name="trash-outline"></ion-icon>
         </ion-button>
       </ion-item>

--- a/people-counting-system/people-counting-client/src/app/device/device.page.ts
+++ b/people-counting-system/people-counting-client/src/app/device/device.page.ts
@@ -30,6 +30,7 @@ import {
 } from 'ionicons/icons';
 
 import { Observable, of } from 'rxjs';
+import { DeviceService, Device } from '../services/device.service';
 
 @Component({
   selector: 'app-device',
@@ -58,9 +59,9 @@ import { Observable, of } from 'rxjs';
   ],
 })
 export class DevicePage implements OnInit {
-  devices$!: Observable<any[]>;
+  devices$!: Observable<Device[]>;
 
-  constructor() {
+  constructor(private deviceService: DeviceService) {
     addIcons({
       addCircle,
       eyeOutline,
@@ -71,97 +72,6 @@ export class DevicePage implements OnInit {
   }
 
   ngOnInit() {
-    this.devices$ = of([
-      {
-        id: 1,
-        name: 'American Eagle East Door',
-        locationId: 1,
-        active: true,
-        created: '2025-06-01T01:19:25.296Z',
-        updated: '2025-06-01T01:19:25.296Z',
-        deleted: null,
-      },
-      {
-        id: 2,
-        name: 'American Eagle West Door',
-        locationId: 1,
-        active: true,
-        created: '2025-06-01T01:19:25.296Z',
-        updated: '2025-06-01T01:19:25.296Z',
-        deleted: null,
-      },
-      {
-        id: 3,
-        name: 'Woods Grocery North Door',
-        locationId: 2,
-        active: true,
-        created: '2025-06-01T01:19:25.296Z',
-        updated: '2025-06-01T01:19:25.296Z',
-        deleted: null,
-      },
-      {
-        id: 4,
-        name: 'Woods Grocery South Door',
-        locationId: 2,
-        active: true,
-        created: '2025-06-01T01:19:25.296Z',
-        updated: '2025-06-01T01:19:25.296Z',
-        deleted: null,
-      },
-      {
-        id: 5,
-        name: 'Hot Topic',
-        locationId: 3,
-        active: true,
-        created: '2025-06-01T01:19:25.296Z',
-        updated: '2025-06-01T01:19:25.296Z',
-        deleted: null,
-      },
-      {
-        id: 6,
-        name: 'Game Stop',
-        locationId: 4,
-        active: true,
-        created: '2025-06-01T01:19:25.296Z',
-        updated: '2025-06-01T01:19:25.296Z',
-        deleted: null,
-      },
-      {
-        id: 7,
-        name: 'Best Buy East Door',
-        locationId: 5,
-        active: true,
-        created: '2025-06-01T01:19:25.296Z',
-        updated: '2025-06-01T01:19:25.296Z',
-        deleted: null,
-      },
-      {
-        id: 8,
-        name: 'Best Buy West Door',
-        locationId: 5,
-        active: true,
-        created: '2025-06-01T01:19:25.296Z',
-        updated: '2025-06-01T01:19:25.296Z',
-        deleted: null,
-      },
-      {
-        id: 9,
-        name: 'Target East Door',
-        locationId: 6,
-        active: true,
-        created: '2025-06-01T01:19:25.296Z',
-        updated: '2025-06-01T01:19:25.296Z',
-        deleted: null,
-      },
-      {
-        id: 10,
-        name: 'Target West Door',
-        locationId: 6,
-        active: true,
-        created: '2025-06-01T01:19:25.296Z',
-        updated: '2025-06-01T01:19:25.296Z',
-        deleted: null,
-      },
-    ]);
+    this.devices$ = this.deviceService.getDevices();
   }
 }

--- a/people-counting-system/people-counting-client/src/app/device/device.page.ts
+++ b/people-counting-system/people-counting-client/src/app/device/device.page.ts
@@ -74,4 +74,16 @@ export class DevicePage implements OnInit {
   ngOnInit() {
     this.devices$ = this.deviceService.getDevices();
   }
+
+  deleteDevice(id?: number) {
+    if (id === undefined) return;
+    this.deviceService.deleteDevice(id).subscribe({
+      next: () => {
+        this.devices$ = this.deviceService.getDevices();
+      },
+      error: err => {
+        console.error('Failed to delete device', err);
+      }
+    });
+}
 }

--- a/people-counting-system/people-counting-client/src/app/edit-device/edit-device.page.ts
+++ b/people-counting-system/people-counting-client/src/app/edit-device/edit-device.page.ts
@@ -2,6 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
+import { DeviceService, Device } from '../services/device.service';
+import { Router } from '@angular/router';
+
 import { 
   IonContent,
   IonHeader,
@@ -70,104 +73,15 @@ import { ActivatedRoute } from '@angular/router';
 })
 
 export class EditDevicePage implements OnInit {
-  device = { name: '', location: 0, active: false };
+  device: Partial<Device> = { name: '', locationId: 0, active: false };
   locations$!: Observable<any[]>;
+  deviceId!: number;
 
-  // Mock devices and locations need updated to use actual data from db
-  private devices = [
-    {
-      id: 1,
-      name: 'American Eagle East Door',
-      locationId: 1,
-      active: true,
-      created: '2025-06-01T01:19:25.296Z',
-      updated: '2025-06-01T01:19:25.296Z',
-      deleted: null,
-    },
-    {
-      id: 2,
-      name: 'American Eagle West Door',
-      locationId: 1,
-      active: true,
-      created: '2025-06-01T01:19:25.296Z',
-      updated: '2025-06-01T01:19:25.296Z',
-      deleted: null,
-    },
-    {
-      id: 3,
-      name: 'Woods Grocery North Door',
-      locationId: 2,
-      active: true,
-      created: '2025-06-01T01:19:25.296Z',
-      updated: '2025-06-01T01:19:25.296Z',
-      deleted: null,
-    },
-    {
-      id: 4,
-      name: 'Woods Grocery South Door',
-      locationId: 2,
-      active: true,
-      created: '2025-06-01T01:19:25.296Z',
-      updated: '2025-06-01T01:19:25.296Z',
-      deleted: null,
-    },
-    {
-      id: 5,
-      name: 'Hot Topic',
-      locationId: 3,
-      active: true,
-      created: '2025-06-01T01:19:25.296Z',
-      updated: '2025-06-01T01:19:25.296Z',
-      deleted: null,
-    },
-    {
-      id: 6,
-      name: 'Game Stop',
-      locationId: 4,
-      active: true,
-      created: '2025-06-01T01:19:25.296Z',
-      updated: '2025-06-01T01:19:25.296Z',
-      deleted: null,
-    },
-    {
-      id: 7,
-      name: 'Best Buy East Door',
-      locationId: 5,
-      active: true,
-      created: '2025-06-01T01:19:25.296Z',
-      updated: '2025-06-01T01:19:25.296Z',
-      deleted: null,
-    },
-    {
-      id: 8,
-      name: 'Best Buy West Door',
-      locationId: 5,
-      active: true,
-      created: '2025-06-01T01:19:25.296Z',
-      updated: '2025-06-01T01:19:25.296Z',
-      deleted: null,
-    },
-    {
-      id: 9,
-      name: 'Target East Door',
-      locationId: 6,
-      active: true,
-      created: '2025-06-01T01:19:25.296Z',
-      updated: '2025-06-01T01:19:25.296Z',
-      deleted: null,
-    },
-    {
-      id: 10,
-      name: 'Target West Door',
-      locationId: 6,
-      active: true,
-      created: '2025-06-01T01:19:25.296Z',
-      updated: '2025-06-01T01:19:25.296Z',
-      deleted: null,
-    },
-  ];
-
-  constructor(private route: ActivatedRoute) {
+  constructor(
+    private deviceService: DeviceService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {
     addIcons({
       addCircle,
       eyeOutline,
@@ -187,19 +101,24 @@ export class EditDevicePage implements OnInit {
       { id: 6, name: 'Target', address: '303 Retail Dr' },
     ]);
 
-const id = Number(this.route.snapshot.paramMap.get('id'));
-    const found = this.devices.find(dev => dev.id === id);
-    if (found) {
-      this.device = {
-        name: found.name,
-        location: found.locationId,
-        active: found.active
-      };
-    }
+    this.deviceId = Number(this.route.snapshot.paramMap.get('id'));
+    this.deviceService.getDevice(this.deviceId).subscribe({
+      next: dev => this.device = dev,
+      error: err => {
+        // TODO: Show error to user
+        console.error('Failed to load device', err);
+      }
+    });
   }
 
   updateDevice() {
-    // Logic to update the device
-    console.log('Device updated', this.device);
+    if (!this.device.name || !this.device.locationId) return;
+    this.deviceService.updateDevice(this.deviceId, this.device as Device).subscribe({
+      next: () => this.router.navigate(['/device']),
+      error: err => {
+        // TODO: Show error to user
+        console.error('Failed to update device', err);
+      }
+    });
   }
 }

--- a/people-counting-system/people-counting-client/src/app/services/device.service.ts
+++ b/people-counting-system/people-counting-client/src/app/services/device.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
+export interface Device {
+  id?: number;
+  name: string;
+  locationId: number;
+  active: boolean;
+  created?: string;
+  updated?: string;
+  deleted?: string | null;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DeviceService {
+  private apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getDevices(): Observable<Device[]> {
+    return this.http.get<{ devices: Device[] }>(`${this.apiUrl}/device`).pipe(
+      map(res => res.devices),
+      catchError(err => throwError(() => err))
+    );
+  }
+
+  getDevice(id: number): Observable<Device> {
+    return this.http.get<{ device: Device }>(`${this.apiUrl}/device/${id}`).pipe(
+      map(res => res.device),
+      catchError(err => throwError(() => err))
+    );
+  }
+
+  createDevice(device: Device): Observable<Device> {
+    return this.http.post<{ device: Device }>(`${this.apiUrl}/device`, device).pipe(
+      map(res => res.device),
+      catchError(err => throwError(() => err))
+    );
+  }
+
+  updateDevice(id: number, device: Device): Observable<Device> {
+    return this.http.put<{ device: Device }>(`${this.apiUrl}/device/${id}`, device).pipe(
+      map(res => res.device),
+      catchError(err => throwError(() => err))
+    );
+  }
+
+  deleteDevice(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/device/${id}`).pipe(
+      catchError(err => throwError(() => err))
+    );
+  }
+}

--- a/people-counting-system/people-counting-client/src/environments/environment.ts
+++ b/people-counting-system/people-counting-client/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiUrl: 'http://localhost:3001/v1',
 };
 
 /*

--- a/people-counting-system/people-counting-client/src/main.ts
+++ b/people-counting-system/people-counting-client/src/main.ts
@@ -1,6 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
 import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
@@ -10,5 +11,6 @@ bootstrapApplication(AppComponent, {
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
+    provideHttpClient(),
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
 
   people-counting-system/people-counting-api:
     dependencies:
+      '@koa/cors':
+        specifier: ^5.0.0
+        version: 5.0.0
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -46,6 +49,9 @@ importers:
       '@types/koa-router':
         specifier: ^7.4.8
         version: 7.4.8
+      '@types/koa__cors':
+        specifier: ^5.0.0
+        version: 5.0.0
       '@types/node':
         specifier: ^22.15.19
         version: 22.15.19
@@ -1469,6 +1475,10 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  '@koa/cors@5.0.0':
+    resolution: {integrity: sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==}
+    engines: {node: '>= 14.0.0'}
+
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
@@ -2059,6 +2069,9 @@ packages:
 
   '@types/koa@2.15.0':
     resolution: {integrity: sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==}
+
+  '@types/koa__cors@5.0.0':
+    resolution: {integrity: sha512-LCk/n25Obq5qlernGOK/2LUwa/2YJb2lxHUkkvYFDOpLXlVI6tKcdfCHRBQnOY4LwH6el5WOLs6PD/a8Uzau6g==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -7214,6 +7227,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@koa/cors@5.0.0':
+    dependencies:
+      vary: 1.1.2
+
   '@leichtgewicht/ip-codec@2.0.5': {}
 
   '@listr2/prompt-adapter-inquirer@2.0.18(@inquirer/prompts@7.3.2(@types/node@22.15.19))':
@@ -7733,6 +7750,10 @@ snapshots:
       '@types/keygrip': 1.0.6
       '@types/koa-compose': 3.2.8
       '@types/node': 22.15.19
+
+  '@types/koa__cors@5.0.0':
+    dependencies:
+      '@types/koa': 2.15.0
 
   '@types/mime@1.3.5': {}
 


### PR DESCRIPTION
## Backend: CORS and API Integration

- Added `@koa/cors` to dependencies
- Updated `app.ts` to use `cors()` middleware

---

## Client: Environment Configuration

- `apiUrl` stored in the environment file as requested

---

## Device Service

Implemented full CRUD operations:

- `getDevice(id)`
- `getDevices()`
- `createDevice(device)`
- `updateDevice(id, device)`
- `deleteDevice(id)`

---

## Device Page

- Integrated with backend using `DeviceService`
- Devices fetched from API using `ngOnInit()`
- Delete functionality implemented
- HTML updated to reflect changes

---

## Add/Edit Device Pages

- Integrated with backend using `DeviceService`
- Add and edit functionality working as expected
- Locations still use dummy data will be addressed in [Issue #18](#)
- HTML updated to reflect changes

---
